### PR TITLE
The RGB output is now of an abitrary range.

### DIFF
--- a/HSBColor.cpp
+++ b/HSBColor.cpp
@@ -4,17 +4,14 @@
 /* HSB to RGB conversion function
 	 INPUT PARAMETERS: Hue values should range from 0 to 360, Saturation and Brightness values should range from 0 to 100
 					   Colors pointer should resolve to an array with 3 elements
-	 RGB values are passed back using via the array. Each value will range between 0 and 255
+	 RGB values are passed back using via the array. Each value will range between 0 and max_rgb_value
 */
-void H2R_HSBtoRGB(int hue, int sat, int bright, int* colors) {
+void H2R_HSBtoRGB_max(int hue, int sat, int bright, int max_rgb_val, int* colors) {
 		
 	// constrain all input variables to expected range
     hue = constrain(hue, 0, 360);
     sat = constrain(sat, 0, 100);
     bright = constrain(bright, 0, 100);
-
-	// define maximum value for RGB array elements
-	float max_rgb_val = H2R_MAX_RGB_val;
 
 	// convert saturation and brightness value to decimals and init r, g, b variables
     float sat_f = float(sat) / 100.0;
@@ -81,11 +78,31 @@ void H2R_HSBtoRGB(int hue, int sat, int bright, int* colors) {
     }
 }
 
-void H2R_HSBtoRGBfloat(float hue, float sat, float bright, int* colors) {
+
+/*
+INPUT PARAMETERS: Hue values should range from 0 to 360, Saturation and Brightness values should range from 0 to 100
+					   Colors pointer should resolve to an array with 3 elements
+	 RGB values are passed back using via the array. Each value will range between 0 and 255
+*/
+void H2R_HSBtoRGB(int hue, int sat, int bright, int* colors) {
+    H2R_HSBtoRGB_max(hue, sat, bright, H2R_MAX_RGB_val, colors);
+}
+
+
+/*
+INPUT PARAMETERS: Hue, Saturation and Brightness values should range from 0 to 1.
+					   Colors pointer should resolve to an array with 3 elements
+	 RGB values are passed back using via the array. Each value will range between 0 and 255
+*/
+void H2R_HSBtoRGBfloat_max(float hue, float sat, float bright, int max_rgb_val, int* colors) {
 	if (hue > 1) hue = 1.0;
 	if (sat > 1) sat = 1.0;
 	if (bright > 1) bright = 1.0;
-    H2R_HSBtoRGB(hue*360.0, sat*100.0, bright*100.0, colors); 
+    H2R_HSBtoRGB_max(hue*360.0, sat*100.0, bright*100.0, max_rgb_val, colors);
+}
+
+void H2R_HSBtoRGBfloat(float hue, float sat, float bright, int* colors) {
+    H2R_HSBtoRGBfloat_max(hue*360.0, sat*100.0, bright*100.0, H2R_MAX_RGB_val, colors);
 }
 
 

--- a/HSBColor.h
+++ b/HSBColor.h
@@ -19,6 +19,9 @@
 
 #define H2R_MAX_RGB_val 255.0
 
+void H2R_HSBtoRGB_max(int, int, int, int, int*);
+void H2R_HSBtoRGBfloat_max(float, float, float, int, int*);
+
 void H2R_HSBtoRGB(int, int, int, int*);
 void H2R_HSBtoRGBfloat(float, float, float, int*);
 

--- a/README.md
+++ b/README.md
@@ -14,24 +14,35 @@ Installing the Library
 Using the Library  
 -----------------  
    
-The HSB library provides two different methods that convert HSB to RGB values. They both accept the 4 parameters, three number values and a pointer to an integer array. They differ in that one of them accepts three integers, while the other accepts three float. 
+The HSB library provides two methods that convert HSB to RGB values. Each method accepts the 5 parameters:
+- Three number values for Hue, Saturation and Brightness;
+- A number the maximum value for each of the RGB component values;
+- and a pointer to an integer array.
+The methods differ in that one of them accepts three integers, while the other accepts three floats.
 
-The RGB values are saved into the integer array that is passed as the fourth parameter of each method. RGB values will range between 0 and 255. Make sure the array can accommodate three integers, otherwise the sketch won't work (though it may compile). 
+The RGB values are saved into the integer array that is passed as the fifth parameter of each method. RGB values will range between 0 and the value given as the fourth parameter. Make sure the array can accommodate three integers, otherwise the sketch won't work (though it may compile).
+
+The library also contains two convenience methods that accept only 4 parameters:
+- Three number values for Hue, Saturation and Brightness;
+- A pointer to an integer array.
+RGB values will range between 0 and 255.
 
 **Integer Method**
 ```
-void H2R_HSBtoRGB(int hue, int saturation, int brightness, int* rbg_array);
+void H2R_HSBtoRGB_max(int hue, int saturation, int brightness, int max_rgb, int* rgb_array);
 ```
 Value Range:
 * hue: 0 - 359
 * saturation: 0 - 99
 * brightness: 0 - 99
+* max_rgb: 0 - 32767
   
 **Float Method**  
 ```
-void H2R_HSBtoRGBfloat(float hue, float saturation, float brightness, int* rbg_array);
+void H2R_HSBtoRGBfloat_max(float hue, float saturation, float brightness, int max_rgb, int* rgb_array);
 ```
 Float Value Range:
 * hue: 0.0 - 1.0
 * saturation: 0.0 - 1.0
 * brightness: 0.0 - 1.0
+* max_rgb: 0 - 32767


### PR DESCRIPTION
The RGB output was limited to a maximum value of 8bits (255) per channel. 
The existing interface should be unchanged.
